### PR TITLE
fix test payload and support other HTTP methods

### DIFF
--- a/CVE-2022-22965.nse
+++ b/CVE-2022-22965.nse
@@ -2,7 +2,7 @@ description = [[
 Spring Framework 5.2.x / 5.3.x CVE-2022-22965 Remote Code Execution Vulnerability
 
 This script looks the existence of CVE-2022-22965 Spring Framework 5.2.x / 5.3.x RCE 
-uses a payload "/?class.module.classLoader.URLs%5B0%5D=0" through a GET request 
+uses a payload "/?class.module.classLoader.definedPackages%5B0%5D=0" through a GET request
 looking (400) code as response (NON INTRUSIVE)
 
 Inspired by:
@@ -25,7 +25,7 @@ $'https://<target>/path/foo/?class.module.classLoader.URLs%5B0%5D=0' | grep -i 4
 -H $'Host: <target>' 
 -H $'User-Agent: alex666'  
 -H $'Connection: close' 
-$'https://<target>/path/foo/?class.module.classLoader.DefaultAssertionStatus=nosense' | grep -i 400
+$'https://<target>/path/foo/?class.module.classLoader.definedPackages%5B0%5D=0' | grep -i 400
 
 References:
 https://github.com/alt3kx/CVE-2022-22965
@@ -38,14 +38,16 @@ https://www.rapid7.com/blog/post/2022/03/30/spring4shell-zero-day-vulnerability-
 
 ---
 -- @usage
--- nmap -p <port> --script=./CVE-2022-22965.nse <target>
+-- nmap -p <port> --script=./CVE-2022-22965.nse [--script-args 'CVE-2022-22965.path=<PATH>,CVE-2022-22965.method=<HTTP METHOD>'] <target>
+-- @args CVE-2022-22965.path URI path to test; must be a valid path that accepts one or more parameters using data binding (default: <code>/</code>).
+-- @args CVE-2022-22965.method HTTP request method to use (default: <code>GET</code>).
 -- 
 -- @examples:
 -- nmap -p443,8080 --script=./CVE-2022-22965.nse <target> -Pn
--- nmap -p443,8080 --script=./CVE-2022-22965.nse <target> --script-args=CVE-2022-22965.uri="/..;/" -Pn
--- nmap -p443,8080 --script=./CVE-2022-22965.nse <target> --script-args=CVE-2022-22965.uri="/path/foo/" -Pn 
--- nmap -p443,8080 --script=./CVE-2022-22965.nse <target> --script-args=CVE-2022-22965.uri="/path/foo/download/" -Pn --script-trace | more
--- nmap -p443,8080 --script=./CVE-2022-22965.nse --script-args=CVE-2022-22965.uri="/examples/" -Pn -iL targets.txt 
+-- nmap -p443,8080 --script=./CVE-2022-22965.nse <target> --script-args 'CVE-2022-22965.path="/path/to/test"' -Pn
+-- nmap -p443,8080 --script=./CVE-2022-22965.nse <target> --script-args 'CVE-2022-22965.path="/path/to/test",CVE-2022-22965.method=POST' -Pn
+-- nmap -p443,8080 --script=./CVE-2022-22965.nse <target> --script-args=CVE-2022-22965.path="/path/foo/download/" -Pn --script-trace | more
+-- nmap -p443,8080 --script=./CVE-2022-22965.nse --script-args=CVE-2022-22965.path="/examples/" -Pn -iL targets.txt
 -- 
 -- @output
 -- PORT    STATE SERVICE
@@ -82,7 +84,7 @@ local S4S4 = "Tomcat"
 --Payloads: 
 --GET checker path2 = "/?class.module.classLoader.DefaultAssertionStatus=nosense"
 --GET checker path1 = "/?class.module.classLoader.URLs%5B0%5D=0"
-local S4S_CHECKER_URI = "/?class.module.classLoader.URLs%5B0%5D=0"
+local S4S_PAYLOAD = "class.module.classLoader.definedPackages%5B0%5D=0"
 
 action = function(host, port)
 
@@ -105,14 +107,15 @@ to remote code execution (RCE) via data binding.]],
     
     local report = vulns.Report:new(SCRIPT_NAME, host, port)
 
-    uri = stdnse.get_script_args("CVE-2022-22965.uri") or S4S_CHECKER_URI
-    evil_uri = uri..S4S_CHECKER_URI
-
-    local options = {header={}}
-
-    options['header']['User-Agent'] = "Mozilla/5.0 (Windows NT 6.3; WOW64; rv:44.0) Gecko/20100101 Firefox/44.0"
-
-    local response = http.get(host, port, evil_uri, { header = { ["Content-Type"] = "application/x-www-form-urlencoded"}})
+    local method = string.upper(stdnse.get_script_args("CVE-2022-22965.method") or "GET")
+    local path = stdnse.get_script_args("CVE-2022-22965.path") or "/"
+    local options = {header={["Content-Type"]="application/x-www-form-urlencoded"}}
+    if method == "GET" then
+        path = path .. "?" .. S4S_PAYLOAD
+    else
+        options["content"] = S4S_PAYLOAD
+    end
+    local response = http.generic_request(host, port, method, path, options)
 
     if response.status and response.body then 
 


### PR DESCRIPTION
As others in the Twitter thread referenced in the README have also
noted, the original test payload that uses
`class.module.classLoader.URLs` is prone to false negatives because not
every classloader implementation has a `getURLs()` method.

While several alternative test payloads have been suggested, this PR
uses `class.module.classLoader.definedPackages%5B0%5D=0` because the
`getDefinedPackages()` method was added to the ClassLoader API in JDK 9
(so it’s another strong signal of vulnerability, and less likely to
cause false positives) and the method is `final`, so custom classloader
implementations can not change its behavior in a way that would cause
false positives or negatives.

This PR also fixes a bug when no `CVE-2022-22965.uri` script argument
was provided and adds support for testing with other HTTP request
methods including POST. The `CVE-2022-22965.uri` argument is renamed to
`CVE-2022-22965.path` for clarity, and a new optional
`CVE-2022-22965.method` argument is added, which can be set to change
the HTTP request method from `GET` (the default) to another valid method
(e.g. `POST`, `PUT`, etc.).